### PR TITLE
Allow HTTPS and HTTP Auth when communicating with the server

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ For more information, check out DBpedia Spotlight https://github.com/dbpedia-spo
   mlspotlight.configEndpoints(
     {
       "english": {
+      protocol:'https:',
+      auth:'testuser:password123',
       host:'context.aksw.org',
       path:'/spotlight/english',
       port:'8080',

--- a/lib/MDBSpotlight.js
+++ b/lib/MDBSpotlight.js
@@ -12,8 +12,8 @@
  *
 **/
 var lngDetector = new (require('languagedetect'));
-var http = require('http');
-var querystring = require('querystring');
+var request = require('superagent');
+var url = require('url');
 //user define endpoints
 var user_defined_endpoints={};
 var is_fixed_endpoint=0;
@@ -68,54 +68,32 @@ exports.annotate=function(input, cb, err) {
 
       }
     }
-    // Build the post string from an object
-    var post_data = querystring.stringify({
-        'text' : input,
-        'confidence': spotlight_config.confidence,
-        'support' : spotlight_config.support
+    var endpoint = url.format({
+        protocol: spotlight_config.protocol || 'http:',
+        slashes: '//',
+        auth:     spotlight_config.auth,
+        hostname: spotlight_config.host,
+        port:     spotlight_config.port,
+        pathname: spotlight_config.path || '/rest/annotate',
     });
-    var err=0;
-    var options={
-        host: spotlight_config.host,
-        path: spotlight_config.path,
-        port: spotlight_config.port,
-        method:'POST',
-        headers:{
-            "Accept": "application/json",
-            "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
-            'Content-Length': post_data.length
-        }
-    };
-    // Set up the request
-    var post_req = http.request(options, function(res) {
-        res.setEncoding('utf8');
-        res.on('error', function(e) {
-          var response={};
-          var output={'language':lang_arr,
-          'endpoint':spotlight_config.host+':'+spotlight_config.port+spotlight_config.path,
-          'error':e,
-          'response':response}
-          cb(output);
-        });
-        var body='';
-        res.on('data', function (chunk) {
-            body += chunk;
-        });
-        res.on('end', function () {
-            //console.log(body);
-            try{
-                var response=JSON.parse(body);
-            }catch(e){
-                var response={};
-            }
-            var output={'language':lang_arr,
-            'endpoint':spotlight_config.host+':'+spotlight_config.port+spotlight_config.path,
-            'error':0,
-            'response':response}
+
+    request.post(endpoint)
+        .accept('application/json')
+        .set('Content-Type', 'application/x-www-form-urlencoded;charset=UTF-8')
+        .send({
+            'text':       input,
+            'confidence': spotlight_config.confidence,
+            'support':    spotlight_config.support
+        })
+        .end(function(err, res) {
+            debugger;
+            var output = {
+                'language': lang_arr,
+                'endpoint': endpoint,
+                'error':    err,
+                'response': res.body
+            };
             cb(output);
         });
-    });
-    // post the data
-    post_req.write(post_data);
-    post_req.end();
+
 }

--- a/package.json
+++ b/package.json
@@ -22,13 +22,14 @@
   },
   "homepage": "https://github.com/dbpedia-spotlight/DBpediaSpotlight.js",
   "dependencies": {
-    "languagedetect": "~1.1.1"
+    "languagedetect": "~1.1.1",
+    "superagent": "~1.8.0"
   },
   "devDependencies": {
     "chai": "^1.9.2",
     "mocha": "^1.21.4"
   },
   "scripts": {
-  "test": "make test"
+    "test": "make test"
   }
 }


### PR DESCRIPTION
Hey there, I have my DBPedia spotlight server behind a proxy that is on the public Internet, so I use TLS and basic auth to protect it against unauthorised access.

I needed to update this client library to suit, which was really just a matter of switching to [superagent](https://github.com/visionmedia/superagent) for the comms. I figured I would share.
